### PR TITLE
Always run build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,6 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs:
-     - "lint"
-     - "tsc"
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Previously the build job was dependant on the lint and typecheck jobs succeeding. However, on a push, lint and typecheck are skipped which counts as a "failure", which means the build job gets skipped and we never deploy.

Now we just always run build, regardless of whether or not the lint and typecheck jobs succeeded. Deployment can still only happen if the lints passed on the pull request before they were pushed to main.