### PR TITLE
Correctly deploy on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,14 +87,14 @@ jobs:
       run: npm run build
 
     - name: Upload Artifact
-      if: github.event.name == 'push'
+      if: github.event_name == 'push'
       uses: actions/upload-pages-artifact@v1
       with:
         path: "dist"
 
   deploy:
     name: Deploy
-    if: github.event.name == 'push'
+    if: github.event_name == 'push'
     needs:
       - "build"
     runs-on: ubuntu-latest


### PR DESCRIPTION
The previous patch used the wrong syntax, which resulted in the upload step and deploy job being skipped.