### PR TITLE
Use a relative path for script and link tags

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8">
 <title>Limelight</title>
-<script src="index.tsx" type="module" defer></script>
-<link rel="stylesheet" href="index.scss">
+<script type="module" src="./index.tsx"  defer></script>
+<link rel="stylesheet" href="./index.scss">
 <body>
 <div id="app"></div>
 </body>


### PR DESCRIPTION
Using an absolute path results in a 404 when deployed, due to the assets being nested under `limelight/` on GitHub pages.