### PR TITLE
Fix the lint commands in package.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,17 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         DEFAULT_BRANCH: main
         LINTER_RULES_PATH: /
-        FILTER_REGEX_INCLUDE: .*src/.*
+        FILTER_REGEX_INCLUDE: .*/src/.*
         TYPESCRIPT_ES_CONFIG_FILE: .eslintrc.cjs
         JAVASCRIPT_DEFAULT_STYLE: prettier
         TYPESCRIPT_DEFAULT_STYLE: prettier
-        VALIDATE_JAVASCRIPT_STANDARD: false
-        VALIDATE_TYPESCRIPT_STANDARD: false
+        VALIDATE_CSS: true
+        VALIDATE_GITLEAKS: true
+        VALIDATE_HTML: true
+        VALIDATE_JAVASCRIPT_ES: true
+        VALIDATE_JSX: true
+        VALIDATE_TSX: true
+        VALIDATE_TYPESCRIPT_ES: true
   tsc:
     if: github.event_name == 'pull_request'
     name: Typecheck (tsc)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,7 @@
 name: CI
 
 on:
-  pull_request:
-    branches:
-      - "main"
+  pull_request: null
   push:
     branches:
       - "main"

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "build": "parcel build src/index.html",
     "serve": "parcel serve src/index.html",
-    "eslint": "eslint src/**/*.{ts,tsx}",
-    "stylelint": "stylelint src/**/*.scss",
-    "htmlhint": "htmlhint src/**/*.html",
+    "eslint": "eslint \"src/**/*.{ts,tsx}\"",
+    "stylelint": "stylelint \"src/**/*.scss\"",
+    "htmlhint": "htmlhint \"src/**/*.html\"",
     "tsc": "tsc"
   },
   "repository": {


### PR DESCRIPTION
Because the wildcards were not quoted, they were being shell expanded and so only files two levels deep under src were being linted.