### PR TITLE
Validate JEXL expressions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/react-bootstrap": "^0.32.31",
         "@types/react-dom": "^18.0.7",
         "bootstrap": "^5.2.2",
+        "mozjexl": "^1.1.6",
         "react": "^18.2.0",
         "react-bootstrap": "^2.5.0",
         "react-dom": "^18.2.0",
@@ -5075,6 +5076,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/mozjexl": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/mozjexl/-/mozjexl-1.1.6.tgz",
+      "integrity": "sha512-34nvJEO7yLjMxooe0qfVUfBvotz270UFuhX0MmTM/0tR5HPJpjTYQLE7IyNag7EF6HPNmnBu0Y6kKoH6MvH8Lw=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -10645,6 +10651,11 @@
         "is-plain-obj": "^1.1.0",
         "kind-of": "^6.0.3"
       }
+    },
+    "mozjexl": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/mozjexl/-/mozjexl-1.1.6.tgz",
+      "integrity": "sha512-34nvJEO7yLjMxooe0qfVUfBvotz270UFuhX0MmTM/0tR5HPJpjTYQLE7IyNag7EF6HPNmnBu0Y6kKoH6MvH8Lw=="
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/react-bootstrap": "^0.32.31",
     "@types/react-dom": "^18.0.7",
     "bootstrap": "^5.2.2",
+    "mozjexl": "^1.1.6",
     "react": "^18.2.0",
     "react-bootstrap": "^2.5.0",
     "react-dom": "^18.2.0",

--- a/src/components/Wizard/InfoBarWizard/index.tsx
+++ b/src/components/Wizard/InfoBarWizard/index.tsx
@@ -24,7 +24,7 @@ import {
   RegisteredFormCheck,
   RegisteredFormRange,
 } from "../../RegisteredFormControl";
-import { validateJsonAsObject } from "../validators";
+import { validateJexl, validateJsonAsObject } from "../validators";
 import ErrorMessage from "../../ErrorMessage";
 import { InfoBarMessage, localizableTextToJson } from "../messageTypes";
 
@@ -200,8 +200,12 @@ export default function InfoBarWizard({
                     <RegisteredFormControl
                       name="meta.targeting"
                       register={register}
-                      registerOptions={{ required: true }}
+                      registerOptions={{
+                        required: true,
+                        validate: validateJexl,
+                      }}
                       as="textarea"
+                      className="input-monospace"
                     />
                     <ErrorMessage name="meta.targeting" />
                   </div>

--- a/src/components/Wizard/validators.ts
+++ b/src/components/Wizard/validators.ts
@@ -4,6 +4,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import evalJexl from "../../jexl";
+
 /**
  * Validate the given string parses as a JSON object.
  */
@@ -18,6 +20,16 @@ export function validateJsonAsObject(s: string): true | string {
 
   if (typeof obj !== "object" || obj === null) {
     return "Expected a JSON object";
+  }
+
+  return true;
+}
+
+export async function validateJexl(s: string): Promise<true | string> {
+  try {
+    await evalJexl(s);
+  } catch (e) {
+    return String(e);
   }
 
   return true;

--- a/src/jexl.ts
+++ b/src/jexl.ts
@@ -1,0 +1,32 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import mozjexl from "mozjexl";
+
+const jexl = new mozjexl.Jexl();
+
+jexl.addTransforms({
+  date: (s: unknown) => (typeof s === "string" ? new Date(s) : undefined),
+  stableSample: () => false,
+  bucketSample: () => false,
+  preferenceValue: () => false,
+  preferenceIsUserSet: () => false,
+  preferenceExists: () => false,
+  keys: () => [],
+  length: () => 0,
+  mapToProperty: () => [],
+  regExpMatch: () => false,
+  versionCompare: () => 0,
+});
+
+jexl.addBinaryOp("intersection", 40, (): unknown[] => []);
+
+export default function evalJexl(
+  expr: string,
+  context: object = {}
+): Promise<unknown> {
+  return jexl.eval(expr, context);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,13 @@
             "DOM",
             "ES2022"
         ],
-        "noEmit": true
+        "noEmit": true,
+        "typeRoots": [
+            "./types",
+            "./node_modules/@types",
+        ]
     },
+    "exclude": ["node_modules"],
     "files": [
         "src/index.tsx"
     ]

--- a/types/mozjexl/index.d.ts
+++ b/types/mozjexl/index.d.ts
@@ -1,0 +1,34 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+type BinaryOperator = (arg0: unknown, arg1: unknown) => unknown;
+type UnaryOperator = (arg0: unknown) => unknown;
+type Callback = (error: Error | null, value?: unknown) => unknown;
+type Transform = (value: unknown, args: object, arg2: Callback) => unknown;
+type Transforms = {
+  [key: string]: Transform;
+};
+
+declare module "mozjexl" {
+  class Jexl {
+    constructor();
+
+    addBinaryOp(operator: string, precedence: number, fn: BinaryOperator): void;
+
+    addUnaryOp(operator: string, fn: UnaryOperator): void;
+
+    addTransform(name: string, fn: Transform): void;
+
+    addTransforms(transforms: Transforms): void;
+
+    getTransform(name: string): Transform | undefined;
+
+    eval(expression: string, cb?: Callback): Promise<unknown>;
+    eval(expression: string, context?: object, cb?: Callback): Promise<unknown>;
+
+    removeOp(operator: string): void;
+  }
+}


### PR DESCRIPTION
We now parse and evaluate the JEXL provided in the "targeting" field, albeit without the context provided by the browser and with mocked out operators.

Fixes #11