### PR TITLE
Fix overflow in field help text

### DIFF
--- a/src/components/Wizard/wizard.scss
+++ b/src/components/Wizard/wizard.scss
@@ -28,6 +28,7 @@
 
     & > .row-help-text {
         @extend .offset-2;
+        @extend .col-10;
     }
 
 }


### PR DESCRIPTION
The field help text is marked as being at a 2-column offset, but doesn't have a column width, which means it defaults to 12 columns, causing horizontal overflow.