### PR TITLE
Correctly focus hidden invalid controls

### DIFF
--- a/src/components/LocalizableTextInput/index.tsx
+++ b/src/components/LocalizableTextInput/index.tsx
@@ -4,7 +4,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { useFormContext, FieldPathByValue } from "react-hook-form";
+import {
+  useFormContext,
+  FieldPathByValue,
+  UseFormRegister,
+} from "react-hook-form";
 
 import FormRow from "../Wizard/FormRow";
 import ErrorMessage from "../ErrorMessage";
@@ -22,6 +26,7 @@ interface LocalizableTextInputProps {
   required?: boolean;
   disabled?: boolean;
   rich?: boolean;
+  register?: UseFormRegister<WizardFormData>;
 }
 
 export const RichTextPresets = {
@@ -45,9 +50,13 @@ export default function LocalizableTextInput({
   required = false,
   disabled = false,
   rich = undefined,
+  register = undefined,
 }: LocalizableTextInputProps) {
-  const { register, watch } = useFormContext<WizardFormData>();
+  const context = useFormContext<WizardFormData>();
+  const { watch } = context;
   const localized = watch(`${controlPrefix}.localized`) ?? false;
+
+  register = register ?? context.register;
 
   return (
     <FormRow label={label} helpText={helpText}>

--- a/src/components/Wizard/InfoBarWizard/InfoBarButtonsInput.tsx
+++ b/src/components/Wizard/InfoBarWizard/InfoBarButtonsInput.tsx
@@ -9,7 +9,6 @@ import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
 import { faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { useFormContext } from "react-hook-form";
 
 import FormRow from "../FormRow";
 import InfoBarWizardFormData from "./formData";
@@ -34,10 +33,8 @@ function defaults(): InfoBarWizardFormData["content"]["buttons"][number] {
 
 const controlPrefix = "content.buttons";
 
-export default function InfoBaorButtonsInput() {
-  const { register } = useFormContext<InfoBarWizardFormData>();
-
-  const renderTab = ({ index, handleDelete }: TabInputProps) => {
+export default function InfoBarButtonsInput() {
+  const renderTab = ({ index, handleDelete, register }: TabInputProps) => {
     const tabControlPrefix = `${controlPrefix}.${index}` as const;
     return (
       <>
@@ -45,6 +42,7 @@ export default function InfoBaorButtonsInput() {
           controlPrefix={`${tabControlPrefix}.label`}
           label="Label"
           required
+          register={register}
         />
 
         <FormRow label="Access Key" controlId={`${controlPrefix}.accessKey`}>

--- a/src/components/Wizard/SpotlightWizard/SpotlightButtonInput.tsx
+++ b/src/components/Wizard/SpotlightWizard/SpotlightButtonInput.tsx
@@ -7,13 +7,18 @@
 import { useEffect } from "react";
 import Form from "react-bootstrap/Form";
 import Row from "react-bootstrap/Row";
-import { useFormContext, FieldPathByValue } from "react-hook-form";
+import {
+  useFormContext,
+  FieldPathByValue,
+  UseFormRegister,
+} from "react-hook-form";
 
 import FormRow from "../FormRow";
 import { RegisteredFormCheck } from "../../RegisteredFormControl";
 import SpotlightWizardFormData, { SpotlightButtonFormData } from "./formData";
 import SpotlightActionInput from "./SpotlightActionInput";
 import LocalizableTextInput from "../../LocalizableTextInput";
+import WizardFormData from "../formData";
 
 interface SpotlightButtonInputProps {
   controlPrefix: FieldPathByValue<
@@ -23,6 +28,7 @@ interface SpotlightButtonInputProps {
   label: string;
   helpText?: string;
   required?: boolean;
+  register: UseFormRegister<WizardFormData>;
 }
 
 export default function SpotlightButtonInput({
@@ -30,9 +36,9 @@ export default function SpotlightButtonInput({
   label,
   helpText = undefined,
   required = false,
+  register,
 }: SpotlightButtonInputProps) {
-  const { register, watch, setValue } =
-    useFormContext<SpotlightWizardFormData>();
+  const { watch, setValue } = useFormContext<SpotlightWizardFormData>();
 
   useEffect(() => {
     if (required) {

--- a/src/components/Wizard/SpotlightWizard/SpotlightLogoInput.tsx
+++ b/src/components/Wizard/SpotlightWizard/SpotlightLogoInput.tsx
@@ -4,12 +4,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { useFormContext } from "react-hook-form";
+import { useFormContext, UseFormRegister } from "react-hook-form";
 import Form from "react-bootstrap/Form";
 import Row from "react-bootstrap/Row";
 
 import FormRow from "../FormRow";
-import SpotlightWizardFormData from "../formData";
+import WizardFormData, { SpotlightWizardFormData } from "../formData";
 import {
   RegisteredFormCheck,
   RegisteredFormControl,
@@ -18,12 +18,14 @@ import ErrorMessage from "../../ErrorMessage";
 
 interface SpotlightLogoInputProps {
   controlPrefix: `content.screens.${number}.content.logo`;
+  register: UseFormRegister<WizardFormData>;
 }
 
 export default function SpotlightLogoInput({
   controlPrefix,
+  register,
 }: SpotlightLogoInputProps) {
-  const { register, watch } = useFormContext<SpotlightWizardFormData>();
+  const { watch } = useFormContext<SpotlightWizardFormData>();
   const hasImageURL = watch(`${controlPrefix}.hasImageURL`);
 
   return (

--- a/src/components/Wizard/SpotlightWizard/SpotlightScreensInput/LogoAndTitleScreen.tsx
+++ b/src/components/Wizard/SpotlightWizard/SpotlightScreensInput/LogoAndTitleScreen.tsx
@@ -4,11 +4,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { useFormContext } from "react-hook-form";
-
 import { ScreenComponentProps, SpotlightScreenKind } from "./screens";
 import FormRow from "../../FormRow";
-import SpotlightWizardFormData from "../formData";
 import {
   RegisteredFormCheck,
   RegisteredFormControl,
@@ -17,12 +14,13 @@ import LocalizableTextInput from "../../../LocalizableTextInput";
 import SpotlightButtonInput from "../SpotlightButtonInput";
 import SpotlightLogoInput from "../SpotlightLogoInput";
 
-function LogoAndTitleScreen({ controlPrefix }: ScreenComponentProps) {
-  const { register } = useFormContext<SpotlightWizardFormData>();
-
+function LogoAndTitleScreen({ controlPrefix, register }: ScreenComponentProps) {
   return (
     <>
-      <SpotlightLogoInput controlPrefix={`${controlPrefix}.logo`} />
+      <SpotlightLogoInput
+        controlPrefix={`${controlPrefix}.logo`}
+        register={register}
+      />
       <FormRow
         label="Background"
         controlId={`${controlPrefix}.background`}
@@ -37,6 +35,7 @@ function LogoAndTitleScreen({ controlPrefix }: ScreenComponentProps) {
       <LocalizableTextInput
         label="Title"
         controlPrefix={`${controlPrefix}.title`}
+        register={register}
         rich
         required
       />
@@ -69,16 +68,19 @@ function LogoAndTitleScreen({ controlPrefix }: ScreenComponentProps) {
       <LocalizableTextInput
         label="Subtitle"
         controlPrefix={`${controlPrefix}.subtitle`}
+        register={register}
         rich
       />
       <SpotlightButtonInput
         label="Primary Button"
         controlPrefix={`${controlPrefix}.primaryButton`}
+        register={register}
         required
       />
       <SpotlightButtonInput
         label="Secondary Button"
         controlPrefix={`${controlPrefix}.secondaryButton`}
+        register={register}
       />
     </>
   );

--- a/src/components/Wizard/SpotlightWizard/SpotlightScreensInput/index.tsx
+++ b/src/components/Wizard/SpotlightWizard/SpotlightScreensInput/index.tsx
@@ -37,8 +37,8 @@ export default function SpotlightScreensInput() {
     useFormContext<SpotlightWizardFormData>();
   const { error } = getFieldState(`content.screens`, formState);
 
-  const renderTab = ({ field, index, handleDelete }: TabInputProps) => (
-    <ScreenInput key={field.id} index={index} handleDelete={handleDelete} />
+  const renderTab = ({ field, ...props }: TabInputProps) => (
+    <ScreenInput key={field.id} field={field} {...props} />
   );
 
   const emptyTabs = () => {
@@ -63,13 +63,9 @@ export default function SpotlightScreensInput() {
   );
 }
 
-interface ScreenInputProps {
-  index: number;
-  handleDelete: (index: number) => void;
-}
-
-function ScreenInput({ index, handleDelete }: ScreenInputProps) {
-  const { register, watch } = useFormContext<SpotlightWizardFormData>();
+function ScreenInput(props: TabInputProps) {
+  const { handleDelete, index, register } = props;
+  const { watch } = useFormContext<SpotlightWizardFormData>();
   const screenControlPrefix = `${controlPrefix}.${index}` as const;
 
   const kind = watch(`${screenControlPrefix}.kind`);
@@ -91,11 +87,11 @@ function ScreenInput({ index, handleDelete }: ScreenInputProps) {
         />
       </FormRow>
 
-      <Component controlPrefix={`${screenControlPrefix}.content`} />
+      <Component controlPrefix={`${screenControlPrefix}.content`} {...props} />
 
       <Row className="form-row form-buttons">
         <Col>
-          <Button variant="danger" onClick={() => handleDelete(index)}>
+          <Button variant="danger" onClick={handleDelete}>
             <FontAwesomeIcon icon={faTrash} /> Delete
           </Button>
         </Col>

--- a/src/components/Wizard/SpotlightWizard/SpotlightScreensInput/screens.ts
+++ b/src/components/Wizard/SpotlightWizard/SpotlightScreensInput/screens.ts
@@ -4,10 +4,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import { TabInputProps } from "../../TabbedInput";
+
 export enum SpotlightScreenKind {
   LogoAndTitle = "LOGO_AND_TITLE",
 }
 
-export interface ScreenComponentProps {
+export interface ScreenComponentProps extends TabInputProps {
   controlPrefix: `content.screens.${number}.content`;
 }


### PR DESCRIPTION
Previously, if a control failed validation but was not visible due to being a child of a `<TabbedInput>` control whose tab is not active, focusing would fail. Form validation usually focuses the first control that is invalid, but when the control isn't visible they cannot be focused.

The way react-hook-form focuses inputs is that `register()` returns a ref callback. To work around this behaviour, we provide our own `register()` function that wraps the library-provided `register()` function but returns a ref callback that calls the original ref callback with the ref wrapped in a `Proxy`. When `focus()` is called on the proxy, the tab will first be activated before the actual focus call.

This results in focusing working correctly when invalid controls are not visible.