### PR TITLE
Refactor TabbedInput focus and add unit tests

### DIFF
--- a/src/components/LocalizableTextInput/index.tsx
+++ b/src/components/LocalizableTextInput/index.tsx
@@ -63,7 +63,11 @@ export default function LocalizableTextInput<TFieldValues extends FieldValues>({
 
   return (
     <FormRow label={label} helpText={helpText}>
-      <FormRow label="Localized?" containerClassName="form-input-check">
+      <FormRow
+        label="Localized?"
+        containerClassName="form-input-check"
+        controlId={fieldname(controlPrefix, "localized")}
+      >
         <RegisteredFormCheck
           name={fieldname(controlPrefix, "localized")}
           register={register}
@@ -72,7 +76,10 @@ export default function LocalizableTextInput<TFieldValues extends FieldValues>({
         />
       </FormRow>
       {localized ? (
-        <FormRow label="String ID">
+        <FormRow
+          label="String ID"
+          controlId={fieldname(controlPrefix, "value")}
+        >
           <RegisteredFormControl
             name={fieldname(controlPrefix, "value")}
             register={register}
@@ -85,7 +92,7 @@ export default function LocalizableTextInput<TFieldValues extends FieldValues>({
           <ErrorMessage name={`${controlPrefix}.value`} />
         </FormRow>
       ) : (
-        <FormRow label="Text">
+        <FormRow label="Text" controlId={fieldname(controlPrefix, "value")}>
           <RegisteredFormControl
             name={fieldname(controlPrefix, "value")}
             register={register}
@@ -101,6 +108,7 @@ export default function LocalizableTextInput<TFieldValues extends FieldValues>({
         <FormRow
           label="Rich Text?"
           helpText="Use the rich text preset used in experiments"
+          controlId={fieldname(controlPrefix, "rich")}
         >
           <RegisteredFormCheck
             name={fieldname(controlPrefix, "rich")}

--- a/src/components/LocalizableTextInput/index.tsx
+++ b/src/components/LocalizableTextInput/index.tsx
@@ -9,7 +9,6 @@ import {
   FieldPathByValue,
   FieldValues,
   Path,
-  UseFormRegister,
 } from "react-hook-form";
 
 import FormRow from "../Wizard/FormRow";
@@ -27,7 +26,6 @@ interface LocalizableTextInputProps<TFieldValues extends FieldValues> {
   required?: boolean;
   disabled?: boolean;
   rich?: boolean;
-  register?: UseFormRegister<TFieldValues>;
 }
 
 export const RichTextPresets = {
@@ -51,15 +49,10 @@ export default function LocalizableTextInput<TFieldValues extends FieldValues>({
   required = false,
   disabled = false,
   rich = undefined,
-  register = undefined,
 }: LocalizableTextInputProps<TFieldValues>) {
-  const context = useFormContext<TFieldValues>();
-  const { watch } = context;
-
+  const { register, watch } = useFormContext<TFieldValues>();
   const localized =
     watch(fieldname<TFieldValues>(controlPrefix, "localized")) ?? false;
-
-  register = register ?? context.register;
 
   return (
     <FormRow label={label} helpText={helpText}>

--- a/src/components/Wizard/InfoBarWizard/InfoBarButtonsInput.tsx
+++ b/src/components/Wizard/InfoBarWizard/InfoBarButtonsInput.tsx
@@ -108,7 +108,7 @@ export default function InfoBarButtonsInput() {
         controlPrefix="content.buttons"
         emptyTabs="There are no buttons."
         renderTab={renderTab}
-        focusName="label.raw"
+        focusName="label.value"
         defaults={defaults}
         addText="Add button"
       />

--- a/src/components/Wizard/InfoBarWizard/InfoBarButtonsInput.tsx
+++ b/src/components/Wizard/InfoBarWizard/InfoBarButtonsInput.tsx
@@ -7,6 +7,7 @@
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
+import { useFormContext } from "react-hook-form";
 import { faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
@@ -37,16 +38,16 @@ export default function InfoBarButtonsInput() {
   const renderTab = ({
     index,
     handleDelete,
-    register,
   }: TabInputProps<WizardFormData, typeof controlPrefix>) => {
+    const { register } = useFormContext<InfoBarWizardFormData>();
     const tabControlPrefix = `${controlPrefix}.${index}` as const;
+
     return (
       <>
         <LocalizableTextInput
           controlPrefix={`${tabControlPrefix}.label`}
           label="Label"
           required
-          register={register}
         />
 
         <FormRow label="Access Key" controlId={`${controlPrefix}.accessKey`}>

--- a/src/components/Wizard/InfoBarWizard/InfoBarButtonsInput.tsx
+++ b/src/components/Wizard/InfoBarWizard/InfoBarButtonsInput.tsx
@@ -19,7 +19,7 @@ import {
 } from "../../RegisteredFormControl";
 import { validateJsonAsObject } from "../validators";
 import ErrorMessage from "../../ErrorMessage";
-import TabbedInput, { TabInputProps } from "../TabbedInput";
+import TabbedInput, { RenderTabProps } from "../TabbedInput";
 import WizardFormData, { InfoBarWizardFormData } from "../formData";
 
 function defaults(): InfoBarWizardFormData["content"]["buttons"][number] {
@@ -38,7 +38,7 @@ export default function InfoBarButtonsInput() {
   const renderTab = ({
     index,
     handleDelete,
-  }: TabInputProps<WizardFormData, typeof controlPrefix>) => {
+  }: RenderTabProps<WizardFormData, typeof controlPrefix>) => {
     const { register } = useFormContext<InfoBarWizardFormData>();
     const tabControlPrefix = `${controlPrefix}.${index}` as const;
 

--- a/src/components/Wizard/InfoBarWizard/InfoBarButtonsInput.tsx
+++ b/src/components/Wizard/InfoBarWizard/InfoBarButtonsInput.tsx
@@ -11,7 +11,6 @@ import { faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import FormRow from "../FormRow";
-import InfoBarWizardFormData from "./formData";
 import LocalizableTextInput from "../../LocalizableTextInput";
 import {
   RegisteredFormControl,
@@ -20,6 +19,7 @@ import {
 import { validateJsonAsObject } from "../validators";
 import ErrorMessage from "../../ErrorMessage";
 import TabbedInput, { TabInputProps } from "../TabbedInput";
+import WizardFormData, { InfoBarWizardFormData } from "../formData";
 
 function defaults(): InfoBarWizardFormData["content"]["buttons"][number] {
   return {
@@ -34,7 +34,11 @@ function defaults(): InfoBarWizardFormData["content"]["buttons"][number] {
 const controlPrefix = "content.buttons";
 
 export default function InfoBarButtonsInput() {
-  const renderTab = ({ index, handleDelete, register }: TabInputProps) => {
+  const renderTab = ({
+    index,
+    handleDelete,
+    register,
+  }: TabInputProps<WizardFormData, typeof controlPrefix>) => {
     const tabControlPrefix = `${controlPrefix}.${index}` as const;
     return (
       <>

--- a/src/components/Wizard/SpotlightWizard/SpotlightButtonInput.tsx
+++ b/src/components/Wizard/SpotlightWizard/SpotlightButtonInput.tsx
@@ -7,18 +7,13 @@
 import { useEffect } from "react";
 import Form from "react-bootstrap/Form";
 import Row from "react-bootstrap/Row";
-import {
-  useFormContext,
-  FieldPathByValue,
-  UseFormRegister,
-} from "react-hook-form";
+import { useFormContext, FieldPathByValue } from "react-hook-form";
 
 import FormRow from "../FormRow";
 import { RegisteredFormCheck } from "../../RegisteredFormControl";
 import SpotlightWizardFormData, { SpotlightButtonFormData } from "./formData";
 import SpotlightActionInput from "./SpotlightActionInput";
 import LocalizableTextInput from "../../LocalizableTextInput";
-import WizardFormData from "../formData";
 
 interface SpotlightButtonInputProps {
   controlPrefix: FieldPathByValue<
@@ -28,7 +23,6 @@ interface SpotlightButtonInputProps {
   label: string;
   helpText?: string;
   required?: boolean;
-  register: UseFormRegister<WizardFormData>;
 }
 
 export default function SpotlightButtonInput({
@@ -36,9 +30,9 @@ export default function SpotlightButtonInput({
   label,
   helpText = undefined,
   required = false,
-  register,
 }: SpotlightButtonInputProps) {
-  const { watch, setValue } = useFormContext<SpotlightWizardFormData>();
+  const { register, setValue, watch } =
+    useFormContext<SpotlightWizardFormData>();
 
   useEffect(() => {
     if (required) {

--- a/src/components/Wizard/SpotlightWizard/SpotlightLogoInput.tsx
+++ b/src/components/Wizard/SpotlightWizard/SpotlightLogoInput.tsx
@@ -4,12 +4,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { useFormContext, UseFormRegister } from "react-hook-form";
+import { useFormContext } from "react-hook-form";
 import Form from "react-bootstrap/Form";
 import Row from "react-bootstrap/Row";
 
 import FormRow from "../FormRow";
-import WizardFormData, { SpotlightWizardFormData } from "../formData";
+import SpotlightWizardFormData from "./formData";
 import {
   RegisteredFormCheck,
   RegisteredFormControl,
@@ -18,14 +18,12 @@ import ErrorMessage from "../../ErrorMessage";
 
 interface SpotlightLogoInputProps {
   controlPrefix: `content.screens.${number}.content.logo`;
-  register: UseFormRegister<WizardFormData>;
 }
 
 export default function SpotlightLogoInput({
   controlPrefix,
-  register,
 }: SpotlightLogoInputProps) {
-  const { watch } = useFormContext<SpotlightWizardFormData>();
+  const { register, watch } = useFormContext<SpotlightWizardFormData>();
   const hasImageURL = watch(`${controlPrefix}.hasImageURL`);
 
   return (

--- a/src/components/Wizard/SpotlightWizard/SpotlightScreensInput/LogoAndTitleScreen.tsx
+++ b/src/components/Wizard/SpotlightWizard/SpotlightScreensInput/LogoAndTitleScreen.tsx
@@ -4,6 +4,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import { useFormContext } from "react-hook-form";
+
 import { ScreenComponentProps, SpotlightScreenKind } from "./screens";
 import FormRow from "../../FormRow";
 import {
@@ -13,14 +15,13 @@ import {
 import LocalizableTextInput from "../../../LocalizableTextInput";
 import SpotlightButtonInput from "../SpotlightButtonInput";
 import SpotlightLogoInput from "../SpotlightLogoInput";
+import SpotlightWizardFormData from "../formData";
 
-function LogoAndTitleScreen({ controlPrefix, register }: ScreenComponentProps) {
+function LogoAndTitleScreen({ controlPrefix }: ScreenComponentProps) {
+  const { register } = useFormContext<SpotlightWizardFormData>();
   return (
     <>
-      <SpotlightLogoInput
-        controlPrefix={`${controlPrefix}.logo`}
-        register={register}
-      />
+      <SpotlightLogoInput controlPrefix={`${controlPrefix}.logo`} />
       <FormRow
         label="Background"
         controlId={`${controlPrefix}.background`}
@@ -35,7 +36,6 @@ function LogoAndTitleScreen({ controlPrefix, register }: ScreenComponentProps) {
       <LocalizableTextInput
         label="Title"
         controlPrefix={`${controlPrefix}.title`}
-        register={register}
         rich
         required
       />
@@ -68,19 +68,16 @@ function LogoAndTitleScreen({ controlPrefix, register }: ScreenComponentProps) {
       <LocalizableTextInput
         label="Subtitle"
         controlPrefix={`${controlPrefix}.subtitle`}
-        register={register}
         rich
       />
       <SpotlightButtonInput
         label="Primary Button"
         controlPrefix={`${controlPrefix}.primaryButton`}
-        register={register}
         required
       />
       <SpotlightButtonInput
         label="Secondary Button"
         controlPrefix={`${controlPrefix}.secondaryButton`}
-        register={register}
       />
     </>
   );

--- a/src/components/Wizard/SpotlightWizard/SpotlightScreensInput/index.tsx
+++ b/src/components/Wizard/SpotlightWizard/SpotlightScreensInput/index.tsx
@@ -19,6 +19,7 @@ import ScreenPicker from "./ScreenPicker";
 import { SpotlightScreenKind } from "./screens";
 import LogoAndTitleScreen from "./LogoAndTitleScreen";
 import ErrorMessage from "../../../ErrorMessage";
+import WizardFormData from "../../formData";
 
 function defaults(): SpotlightScreenFormData {
   return {
@@ -37,7 +38,10 @@ export default function SpotlightScreensInput() {
     useFormContext<SpotlightWizardFormData>();
   const { error } = getFieldState(`content.screens`, formState);
 
-  const renderTab = ({ field, ...props }: TabInputProps) => (
+  const renderTab = ({
+    field,
+    ...props
+  }: TabInputProps<WizardFormData, typeof controlPrefix>) => (
     <ScreenInput key={field.id} field={field} {...props} />
   );
 
@@ -63,7 +67,9 @@ export default function SpotlightScreensInput() {
   );
 }
 
-function ScreenInput(props: TabInputProps) {
+function ScreenInput(
+  props: TabInputProps<WizardFormData, typeof controlPrefix>
+) {
   const { handleDelete, index, register } = props;
   const { watch } = useFormContext<SpotlightWizardFormData>();
   const screenControlPrefix = `${controlPrefix}.${index}` as const;

--- a/src/components/Wizard/SpotlightWizard/SpotlightScreensInput/index.tsx
+++ b/src/components/Wizard/SpotlightWizard/SpotlightScreensInput/index.tsx
@@ -70,8 +70,8 @@ export default function SpotlightScreensInput() {
 function ScreenInput(
   props: TabInputProps<WizardFormData, typeof controlPrefix>
 ) {
-  const { handleDelete, index, register } = props;
-  const { watch } = useFormContext<SpotlightWizardFormData>();
+  const { handleDelete, index } = props;
+  const { register, watch } = useFormContext<SpotlightWizardFormData>();
   const screenControlPrefix = `${controlPrefix}.${index}` as const;
 
   const kind = watch(`${screenControlPrefix}.kind`);

--- a/src/components/Wizard/SpotlightWizard/SpotlightScreensInput/index.tsx
+++ b/src/components/Wizard/SpotlightWizard/SpotlightScreensInput/index.tsx
@@ -10,7 +10,7 @@ import Row from "react-bootstrap/Row";
 import { faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useFormContext } from "react-hook-form";
-import TabbedInput, { TabInputProps } from "../../TabbedInput";
+import TabbedInput, { RenderTabProps } from "../../TabbedInput";
 
 import FormRow from "../../FormRow";
 import SpotlightWizardFormData, { SpotlightScreenFormData } from "../formData";
@@ -41,7 +41,7 @@ export default function SpotlightScreensInput() {
   const renderTab = ({
     field,
     ...props
-  }: TabInputProps<WizardFormData, typeof controlPrefix>) => (
+  }: RenderTabProps<WizardFormData, typeof controlPrefix>) => (
     <ScreenInput key={field.id} field={field} {...props} />
   );
 
@@ -68,7 +68,7 @@ export default function SpotlightScreensInput() {
 }
 
 function ScreenInput(
-  props: TabInputProps<WizardFormData, typeof controlPrefix>
+  props: RenderTabProps<WizardFormData, typeof controlPrefix>
 ) {
   const { handleDelete, index } = props;
   const { register, watch } = useFormContext<SpotlightWizardFormData>();

--- a/src/components/Wizard/SpotlightWizard/SpotlightScreensInput/screens.ts
+++ b/src/components/Wizard/SpotlightWizard/SpotlightScreensInput/screens.ts
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { TabInputProps } from "../../TabbedInput";
+import { RenderTabProps } from "../../TabbedInput";
 import WizardFormData from "../../formData";
 
 export enum SpotlightScreenKind {
@@ -12,6 +12,6 @@ export enum SpotlightScreenKind {
 }
 
 export interface ScreenComponentProps
-  extends TabInputProps<WizardFormData, "content.screens"> {
+  extends RenderTabProps<WizardFormData, "content.screens"> {
   controlPrefix: `content.screens.${number}.content`;
 }

--- a/src/components/Wizard/SpotlightWizard/SpotlightScreensInput/screens.ts
+++ b/src/components/Wizard/SpotlightWizard/SpotlightScreensInput/screens.ts
@@ -5,11 +5,13 @@
  */
 
 import { TabInputProps } from "../../TabbedInput";
+import WizardFormData from "../../formData";
 
 export enum SpotlightScreenKind {
   LogoAndTitle = "LOGO_AND_TITLE",
 }
 
-export interface ScreenComponentProps extends TabInputProps {
+export interface ScreenComponentProps
+  extends TabInputProps<WizardFormData, "content.screens"> {
   controlPrefix: `content.screens.${number}.content`;
 }

--- a/src/components/Wizard/TabbedInput.tsx
+++ b/src/components/Wizard/TabbedInput.tsx
@@ -25,7 +25,7 @@ import {
   FormProvider,
 } from "react-hook-form";
 
-export interface TabInputProps<
+export interface RenderTabProps<
   TFieldValues extends FieldValues,
   TFieldName extends FieldArrayPath<TFieldValues>
 > {
@@ -40,7 +40,7 @@ export interface TabbedInputProps<
 > {
   controlPrefix: TFieldName;
   className?: string;
-  renderTab: (props: TabInputProps<TFieldValues, TFieldName>) => JSX.Element;
+  renderTab: (props: RenderTabProps<TFieldValues, TFieldName>) => JSX.Element;
   emptyTabs: string | (() => JSX.Element);
   focusName?: string;
   defaults: () => FieldArray<TFieldValues, TFieldName>;
@@ -160,7 +160,7 @@ interface TabContentProps<
   field: FieldArrayWithId<TFieldValues, TFieldName>;
   index: number;
   handleDelete: () => void;
-  renderTab: (props: TabInputProps<TFieldValues, TFieldName>) => JSX.Element;
+  renderTab: (props: RenderTabProps<TFieldValues, TFieldName>) => JSX.Element;
 }
 
 function TabContent<

--- a/src/components/Wizard/TabbedInput.tsx
+++ b/src/components/Wizard/TabbedInput.tsx
@@ -34,7 +34,7 @@ export interface TabInputProps<
   register: UseFormRegister<TFieldValues>;
 }
 
-interface TabbedInputProps<
+export interface TabbedInputProps<
   TFieldValues extends FieldValues,
   TFieldName extends FieldArrayPath<TFieldValues>
 > {

--- a/src/components/Wizard/TabbedInput.tsx
+++ b/src/components/Wizard/TabbedInput.tsx
@@ -21,31 +21,37 @@ import {
   UseFormRegister,
   FieldValues,
   Path,
+  FieldArrayPath,
 } from "react-hook-form";
 
-import WizardFormData from "./formData";
-
-type FieldNames = "content.buttons" | "content.screens";
-
-export interface TabInputProps {
-  field: FieldArrayWithId<WizardFormData, FieldNames>;
+export interface TabInputProps<
+  TFieldValues extends FieldValues,
+  TFieldNames extends FieldArrayPath<TFieldValues>
+> {
+  field: FieldArrayWithId<TFieldValues, TFieldNames>;
   index: number;
   handleDelete: () => void;
-  register: UseFormRegister<WizardFormData>;
+  register: UseFormRegister<TFieldValues>;
 }
 
-interface TabbedInputProps {
-  controlPrefix: FieldNames;
+interface TabbedInputProps<
+  TFieldValues extends FieldValues,
+  TFieldName extends FieldArrayPath<TFieldValues>
+> {
+  controlPrefix: TFieldName;
   className?: string;
-  renderTab: (props: TabInputProps) => JSX.Element;
+  renderTab: (props: TabInputProps<TFieldValues, TFieldName>) => JSX.Element;
   emptyTabs: string | (() => JSX.Element);
   focusName?: string;
-  defaults: () => FieldArray<WizardFormData, FieldNames>;
+  defaults: () => FieldArray<TFieldValues, TFieldName>;
   addText: string;
   rules?: UseFieldArrayProps["rules"];
 }
 
-export default function TabbedInput({
+export default function TabbedInput<
+  TFieldValues extends FieldValues,
+  TFieldName extends FieldArrayPath<TFieldValues>
+>({
   className = undefined,
   controlPrefix,
   emptyTabs,
@@ -54,9 +60,9 @@ export default function TabbedInput({
   defaults,
   addText,
   rules = {},
-}: TabbedInputProps) {
-  const { control, register } = useFormContext<WizardFormData>();
-  const { fields, append, remove } = useFieldArray<WizardFormData, FieldNames>({
+}: TabbedInputProps<TFieldValues, TFieldName>) {
+  const { control, register } = useFormContext<TFieldValues>();
+  const { fields, append, remove } = useFieldArray<TFieldValues, TFieldName>({
     control,
     name: controlPrefix,
     rules: rules,
@@ -105,7 +111,7 @@ export default function TabbedInput({
           field,
           handleDelete,
           index,
-          register: proxyRegister(register, focusTab),
+          register: proxyRegister<TFieldValues>(register, focusTab),
         });
 
         return (

--- a/src/components/Wizard/__tests__/TabbedInput.test.tsx
+++ b/src/components/Wizard/__tests__/TabbedInput.test.tsx
@@ -12,7 +12,7 @@ import { FormProvider, useForm, useFormContext } from "react-hook-form";
 import FormRow from "../FormRow";
 import LocalizableTextInput from "../../LocalizableTextInput";
 import { RegisteredFormControl } from "../../RegisteredFormControl";
-import TabbedInput, { TabInputProps } from "../TabbedInput";
+import TabbedInput, { RenderTabProps } from "../TabbedInput";
 import { LocalizableTextFormData } from "../formData";
 
 interface FormData<T> {
@@ -62,7 +62,7 @@ describe("TabbedInput", () => {
     function renderTab({
       handleDelete,
       index,
-    }: TabInputProps<FormData<string>, typeof CONTROL_PREFIX>) {
+    }: RenderTabProps<FormData<string>, typeof CONTROL_PREFIX>) {
       const { register } = useFormContext<FormData<string>>();
       return (
         <>
@@ -223,7 +223,7 @@ describe("TabbedInput", () => {
     function renderTab({
       handleDelete,
       index,
-    }: TabInputProps<
+    }: RenderTabProps<
       FormData<LocalizableTextFormData>,
       typeof CONTROL_PREFIX
     >) {

--- a/src/components/Wizard/__tests__/TabbedInput.test.tsx
+++ b/src/components/Wizard/__tests__/TabbedInput.test.tsx
@@ -1,0 +1,300 @@
+/*
+ * Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+import { describe, expect, test } from "@jest/globals";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ReactNode } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+
+import FormRow from "../FormRow";
+import LocalizableTextInput from "../../LocalizableTextInput";
+import { RegisteredFormControl } from "../../RegisteredFormControl";
+import TabbedInput, { TabInputProps } from "../TabbedInput";
+import { LocalizableTextFormData } from "../formData";
+
+interface FormData<T> {
+  content: {
+    field: T;
+  }[];
+}
+
+function Wrapper<T>({ children }: { children: ReactNode }) {
+  const context = useForm<FormData<T>>();
+  const { handleSubmit } = context;
+
+  function onSubmit() {
+    // Do nothing.
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <FormProvider {...context}>{children}</FormProvider>
+      <input type="submit" value="submit" />
+    </form>
+  );
+}
+
+function renderWrapped<T>(
+  ...[ui, options]: Parameters<typeof render>
+): ReturnType<typeof render> {
+  return render(ui, { wrapper: Wrapper<T>, ...options });
+}
+
+const ADD_TAB_TEXT = "add tab";
+const DELETE_TAB_TEXT = "delete tab";
+const EMPTY_TABS_TEXT = "there are no tabs";
+const FIELD_LABEL = "Field";
+const FOCUS_FIELD_NAME = "field";
+const CONTROL_PREFIX = "content";
+
+function getFocusedElement() {
+  // eslint-disable-next-line testing-library/no-node-access
+  return document.activeElement;
+}
+
+describe("TabbedInput", () => {
+  describe("rendering a simple field", () => {
+    const defaults = () => ({ field: "" });
+
+    function renderTab({
+      handleDelete,
+      index,
+      register,
+    }: TabInputProps<FormData<string>, typeof CONTROL_PREFIX>) {
+      return (
+        <>
+          <FormRow
+            label={FIELD_LABEL}
+            controlId={`${CONTROL_PREFIX}.${index}.field`}
+          >
+            <RegisteredFormControl
+              register={register}
+              name={`${CONTROL_PREFIX}.${index}.field`}
+              registerOptions={{ required: true }}
+            />
+          </FormRow>
+          <button onClick={handleDelete}>{DELETE_TAB_TEXT}</button>
+        </>
+      );
+    }
+
+    const defaultProps = {
+      controlPrefix: CONTROL_PREFIX,
+      renderTab,
+      emptyTabs: EMPTY_TABS_TEXT,
+      defaults,
+      focusName: FOCUS_FIELD_NAME,
+      addText: ADD_TAB_TEXT,
+    } as const;
+
+    test("empty control", () => {
+      renderWrapped(<TabbedInput {...defaultProps} />);
+      screen.getByTitle(ADD_TAB_TEXT);
+      screen.getByText(EMPTY_TABS_TEXT);
+    });
+
+    test("add and remove tabs", async () => {
+      renderWrapped(<TabbedInput {...defaultProps} />);
+
+      const addBtn = screen.getByTitle(ADD_TAB_TEXT);
+
+      // Add a tab.
+      await userEvent.click(addBtn);
+      let tabs = screen.getAllByRole("tab");
+
+      expect(screen.queryByText(EMPTY_TABS_TEXT)).toBeNull();
+
+      // There should be one tab. It should be active.
+      expect(tabs.length).toEqual(1);
+      expect(tabs[0].classList).toContain("active");
+
+      // Add a second tab.
+      await userEvent.click(addBtn);
+      tabs = screen.getAllByRole("tab");
+
+      // There should be two tabs. The second tab should be active.
+      expect(tabs.length).toEqual(2);
+      expect(tabs[1].classList).toContain("active");
+
+      // Add a third tab.
+      await userEvent.click(addBtn);
+      tabs = screen.getAllByRole("tab");
+
+      // There should be three tabs. The third tab should be active.
+      expect(tabs.length).toEqual(3);
+      expect(tabs[2].classList).toContain("active");
+
+      // Remove the third tab.
+      await userEvent.click(screen.getAllByText(DELETE_TAB_TEXT)[2]);
+      tabs = screen.getAllByRole("tab");
+
+      // There should be two tabs. The second tab should be active.
+      expect(tabs.length).toEqual(2);
+      expect(tabs[1].classList).toContain("active");
+
+      // Focus the first tab.
+      await userEvent.click(tabs[0]);
+
+      // It should be active.
+      expect(tabs[0].classList).toContain("active");
+
+      // Delete it.
+      await userEvent.click(screen.getAllByText(DELETE_TAB_TEXT)[0]);
+
+      // The tab should be removed.
+      expect(tabs[0].isConnected).toEqual(false);
+
+      // There should be one tab. It should be aftive.
+      tabs = screen.getAllByRole("tab");
+      expect(tabs.length).toEqual(1);
+      expect(tabs[0].classList).toContain("active");
+
+      // Remove the last tab.
+      await userEvent.click(screen.getByText(DELETE_TAB_TEXT));
+
+      // There should be no more tabs.
+      expect(screen.queryAllByRole("tab")).toEqual([]);
+      screen.getByText(EMPTY_TABS_TEXT);
+    });
+
+    test("focusing a field when adding a tab", async () => {
+      renderWrapped(<TabbedInput {...defaultProps} />);
+
+      const addBtn = screen.getByTitle(ADD_TAB_TEXT);
+
+      // Add a tab.
+      await userEvent.click(addBtn);
+
+      // The field on the first tab should be focused.
+      expect(getFocusedElement()).toBe(screen.getByLabelText(FIELD_LABEL));
+
+      // Add a second tab.
+      await userEvent.click(addBtn);
+
+      // The field on the second tab should be focused.
+      expect(getFocusedElement()).toBe(
+        screen.getAllByLabelText(FIELD_LABEL)[1]
+      );
+    });
+
+    test("focusing a field on an inactive tab", async () => {
+      renderWrapped(<TabbedInput {...defaultProps} />);
+
+      const addBtn = screen.getByTitle(ADD_TAB_TEXT);
+
+      // Add two tabs.
+      await userEvent.click(addBtn);
+      await userEvent.click(addBtn);
+
+      // The second tab should be focused.
+      const tabs = screen.getAllByRole("tab");
+      expect(tabs.length).toEqual(2);
+      expect(tabs[1].classList).toContain("active");
+
+      // Validate the form.
+      await userEvent.click(screen.getByText("submit"));
+
+      // The first tab should be focused.
+      expect(tabs[1].classList).toContain("active");
+
+      // The input element is not focused immediately because it has to wait for the transition to complete.
+      await waitFor(() =>
+        expect(getFocusedElement()).toBe(
+          screen.getAllByLabelText(FIELD_LABEL)[0]
+        )
+      );
+    });
+  });
+
+  describe("rendering a complex field (LocalizableTextInput)", () => {
+    const defaults = () => ({
+      field: {
+        localized: false,
+        value: "",
+      },
+    });
+    const FOCUS_NAME = "field.value";
+    const ADD_TAB_TEXT = "add tab";
+    const DELETE_TAB_TEXT = "delete tab";
+
+    function renderTab({
+      handleDelete,
+      index,
+      register,
+    }: TabInputProps<
+      FormData<LocalizableTextFormData>,
+      typeof CONTROL_PREFIX
+    >) {
+      return (
+        <>
+          <FormRow label="Field">
+            <LocalizableTextInput
+              controlPrefix={`${CONTROL_PREFIX}.${index}.field`}
+              register={register}
+              label={FIELD_LABEL}
+              required
+            />
+          </FormRow>
+          <button onClick={handleDelete}>{DELETE_TAB_TEXT}</button>
+        </>
+      );
+    }
+
+    const defaultProps = {
+      controlPrefix: CONTROL_PREFIX,
+      renderTab,
+      emptyTabs: EMPTY_TABS_TEXT,
+      defaults,
+      focusName: FOCUS_NAME,
+      addText: ADD_TAB_TEXT,
+    } as const;
+
+    test("focusing a field when adding a tab", async () => {
+      renderWrapped(<TabbedInput {...defaultProps} />);
+
+      const addBtn = screen.getByTitle(ADD_TAB_TEXT);
+
+      // Add a tab.
+      await userEvent.click(addBtn);
+
+      // The field on the first tab should be focused.
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(getFocusedElement()).toBe(screen.getByLabelText("Text"));
+
+      // Add a second tab.
+      await userEvent.click(addBtn);
+
+      // The field on the second tab should be focused.
+      expect(getFocusedElement()).toBe(screen.getAllByLabelText("Text")[1]);
+    });
+
+    test("focusing a field on an inactive tab", async () => {
+      renderWrapped(<TabbedInput {...defaultProps} />);
+
+      const addBtn = screen.getByTitle(ADD_TAB_TEXT);
+
+      // Add two tabs.
+      await userEvent.click(addBtn);
+      await userEvent.click(addBtn);
+
+      // The second tab should be focused.
+      const tabs = screen.getAllByRole("tab");
+      expect(tabs.length).toEqual(2);
+      expect(tabs[1].classList).toContain("active");
+
+      // Validate the form.
+      await userEvent.click(screen.getByText("submit"));
+
+      // The first tab should be focused.
+      expect(tabs[1].classList).toContain("active");
+
+      // The input element is not focused immediately because it has to wait for the transition to complete.
+      await waitFor(() =>
+        expect(getFocusedElement()).toBe(screen.getAllByLabelText("Text")[0])
+      );
+    });
+  });
+});

--- a/src/components/Wizard/__tests__/TabbedInput.test.tsx
+++ b/src/components/Wizard/__tests__/TabbedInput.test.tsx
@@ -7,7 +7,7 @@ import { describe, expect, test } from "@jest/globals";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ReactNode } from "react";
-import { FormProvider, useForm } from "react-hook-form";
+import { FormProvider, useForm, useFormContext } from "react-hook-form";
 
 import FormRow from "../FormRow";
 import LocalizableTextInput from "../../LocalizableTextInput";
@@ -62,8 +62,8 @@ describe("TabbedInput", () => {
     function renderTab({
       handleDelete,
       index,
-      register,
     }: TabInputProps<FormData<string>, typeof CONTROL_PREFIX>) {
+      const { register } = useFormContext<FormData<string>>();
       return (
         <>
           <FormRow
@@ -223,7 +223,6 @@ describe("TabbedInput", () => {
     function renderTab({
       handleDelete,
       index,
-      register,
     }: TabInputProps<
       FormData<LocalizableTextFormData>,
       typeof CONTROL_PREFIX
@@ -233,7 +232,6 @@ describe("TabbedInput", () => {
           <FormRow label="Field">
             <LocalizableTextInput
               controlPrefix={`${CONTROL_PREFIX}.${index}.field`}
-              register={register}
               label={FIELD_LABEL}
               required
             />


### PR DESCRIPTION
`TabbedInput` has been refactored to use a `FormProvider` instead of passing the `register` function as a prop. Additionally, unit tests have been added for `TabbedInput` that cover this behaviour, as well as adding and removing tabs.