### PR TITLE
Miscellaneous cleanups

### DIFF
--- a/src/components/App/app.scss
+++ b/src/components/App/app.scss
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+@use "../../defs";
+
 #app {
   min-height: 100vh;
   display: flex;
@@ -10,5 +12,5 @@
 }
 
 .input-monospace {
-  font-family: Menlo, Consolas, "Courier New", monospace;
+  font-family: defs.$monospace-font;
 }

--- a/src/components/LocalizableTextInput/index.tsx
+++ b/src/components/LocalizableTextInput/index.tsx
@@ -102,6 +102,7 @@ export default function LocalizableTextInput<TFieldValues extends FieldValues>({
           label="Rich Text?"
           helpText="Use the rich text preset used in experiments"
           controlId={fieldname(controlPrefix, "rich")}
+          containerClassName="form-input-check"
         >
           <RegisteredFormCheck
             name={fieldname(controlPrefix, "rich")}

--- a/src/components/Wizard/MessageGroupsInput.tsx
+++ b/src/components/Wizard/MessageGroupsInput.tsx
@@ -36,7 +36,7 @@ export default function MessageGroupsInput() {
 
   return (
     <FormRow
-      label="Messge Groups"
+      label="Message Groups"
       controlId={controlId}
       helpText="Message groups used for frequency capping."
     >

--- a/src/components/Wizard/NewEditImportPane.tsx
+++ b/src/components/Wizard/NewEditImportPane.tsx
@@ -134,52 +134,47 @@ function EditForm({ onEditMessage, onDeleteMessage, messages }: EditFormProps) {
     onEditMessage(data.id);
   };
 
-  const onDelete = (id: string) => {
-    onDeleteMessage(id);
-  };
+  const messageIds = Object.keys(messages);
+
   return (
     <>
       <Card.Title>Edit an Existing Message</Card.Title>
 
       <Form onSubmit={handleSubmit(onSubmit)} className="edit-form">
         <FormProvider {...formContext}>
-          <Form.Group controlId="message-select">
+          {messageIds.length ? (
             <FormRow
               label="Select Message"
               containerClassName="form-input-check"
             >
-              {Object.keys(messages).length ? (
-                Object.keys(messages).map((id) => {
-                  return (
-                    <Row className="edit-entry" key={id}>
-                      <RegisteredFormCheck
-                        name="id"
-                        register={register}
-                        registerOptions={{ required: true }}
-                        type="radio"
-                        key={id}
-                        label={id}
-                        value={id}
-                        id={`message-select-${id}`}
-                      />
-                      <div className="delete-col">
-                        <Button
-                          key={`delete-${id}`}
-                          type="button"
-                          variant="danger"
-                          onClick={() => onDelete(id)}
-                        >
-                          <FontAwesomeIcon icon={faTrash} />
-                        </Button>
-                      </div>
-                    </Row>
-                  );
-                })
-              ) : (
-                <Card.Text>There are no messages saved.</Card.Text>
-              )}
+              {messageIds.map((id) => (
+                <Row className="edit-entry" key={id}>
+                  <RegisteredFormCheck
+                    name="id"
+                    register={register}
+                    registerOptions={{ required: true }}
+                    type="radio"
+                    key={id}
+                    label={id}
+                    value={id}
+                    id={`message-select-${id}`}
+                  />
+                  <div className="delete-col">
+                    <Button
+                      key={`delete-${id}`}
+                      type="button"
+                      variant="danger"
+                      onClick={() => onDeleteMessage(id)}
+                    >
+                      <FontAwesomeIcon icon={faTrash} />
+                    </Button>
+                  </div>
+                </Row>
+              ))}
             </FormRow>
-          </Form.Group>
+          ) : (
+            <Card.Text>There are no messages saved.</Card.Text>
+          )}
         </FormProvider>
 
         <div className="form-row form-buttons">

--- a/src/components/Wizard/PriorityInput.tsx
+++ b/src/components/Wizard/PriorityInput.tsx
@@ -4,6 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import Col from "react-bootstrap/Col";
 import Form from "react-bootstrap/Form";
 import Row from "react-bootstrap/Row";
 import { useFormContext } from "react-hook-form";
@@ -39,44 +40,40 @@ export default function PriorityInput() {
             />
           </Form.Group>
         </Row>
-        <Row className="form-row">
-          <FormRow
-            label="Priority"
-            controlId={`${controlPrefix}.value`}
-            column={true}
-          >
-            <RegisteredFormControl
-              name={`${controlPrefix}.value`}
-              register={register}
-              registerOptions={{
-                required: priorityEnabled,
-                disabled: !priorityEnabled,
-                valueAsNumber: true,
-                min: 0,
-                max: 9,
-              }}
-              type="number"
-              defaultValue={0}
-              min={0}
-              max={9}
-            />
-          </FormRow>
-          <FormRow
-            label="Order"
-            controlId={`${controlPrefix}.order`}
-            column={true}
-          >
-            <RegisteredFormControl
-              name={`${controlPrefix}.order`}
-              register={register}
-              registerOptions={{
-                disabled: !priorityEnabled,
-                valueAsNumber: true,
-              }}
-              type="number"
-              min={0}
-            />
-          </FormRow>
+        <Row>
+          <Col>
+            <FormRow label="Priority" controlId={`${controlPrefix}.value`}>
+              <RegisteredFormControl
+                name={`${controlPrefix}.value`}
+                register={register}
+                registerOptions={{
+                  required: priorityEnabled,
+                  disabled: !priorityEnabled,
+                  valueAsNumber: true,
+                  min: 0,
+                  max: 9,
+                }}
+                type="number"
+                defaultValue={0}
+                min={0}
+                max={9}
+              />
+            </FormRow>
+          </Col>
+          <Col>
+            <FormRow label="Order" controlId={`${controlPrefix}.order`}>
+              <RegisteredFormControl
+                name={`${controlPrefix}.order`}
+                register={register}
+                registerOptions={{
+                  disabled: !priorityEnabled,
+                  valueAsNumber: true,
+                }}
+                type="number"
+                min={0}
+              />
+            </FormRow>
+          </Col>
         </Row>
         <Row>
           <Form.Text className="col-help-text">

--- a/src/components/Wizard/SpotlightWizard/SpotlightActionInput.tsx
+++ b/src/components/Wizard/SpotlightWizard/SpotlightActionInput.tsx
@@ -74,7 +74,6 @@ export default function SpotlightActionInput({
           name={`${controlPrefix}.data`}
           register={register}
           registerOptions={{
-            required: !disabled,
             validate: !disabled ? validateJsonAsObject : undefined,
           }}
           disabled={disabled}

--- a/src/components/Wizard/SpotlightWizard/SpotlightScreensInput/LogoAndTitleScreen.tsx
+++ b/src/components/Wizard/SpotlightWizard/SpotlightScreensInput/LogoAndTitleScreen.tsx
@@ -118,7 +118,7 @@ export default Object.assign(LogoAndTitleScreen, {
             navigate: true,
             dismiss: false,
             type: "",
-            data: "{}",
+            data: "",
           },
         },
         secondaryButton: {
@@ -131,7 +131,7 @@ export default Object.assign(LogoAndTitleScreen, {
             navigate: true,
             dismiss: false,
             type: "",
-            data: "{}",
+            data: "",
           },
         },
         dismissButton: {

--- a/src/components/Wizard/SpotlightWizard/index.tsx
+++ b/src/components/Wizard/SpotlightWizard/index.tsx
@@ -28,7 +28,11 @@ export default function SpotlightWizard() {
           containerClassName="form-input-check"
           helpText="Show transitions within and between screens."
         >
-          <RegisteredFormCheck name="content.transitions" register={register} />
+          <RegisteredFormCheck
+            name="content.transitions"
+            register={register}
+            defaultChecked
+          />
         </FormRow>
 
         <FormRow

--- a/src/components/Wizard/index.tsx
+++ b/src/components/Wizard/index.tsx
@@ -179,17 +179,17 @@ export default function Wizard() {
   return (
     <>
       <Container className="wizard">
-        <FormProvider {...formContext}>
-          <Form>
-            <Card>
-              <Card.Header className="d-flex justify-content-between">
-                <Card.Title className="mb-0">
-                  Editing Message:{" "}
-                  <span className="message-id">{messageInfo.id}</span>
-                </Card.Title>
-                <CloseButton onClick={stopEditing} title="Stop Editing" />
-              </Card.Header>
+        <Card>
+          <Card.Header className="d-flex justify-content-between">
+            <Card.Title className="mb-0">
+              Editing Message:{" "}
+              <span className="message-id">{messageInfo.id}</span>
+            </Card.Title>
+            <CloseButton onClick={stopEditing} title="Stop Editing" />
+          </Card.Header>
 
+          <FormProvider {...formContext}>
+            <Form>
               <ListGroup variant="flush">
                 <MessageContentWizard />
 
@@ -210,9 +210,9 @@ export default function Wizard() {
                   </Button>
                 </ListGroup.Item>
               </ListGroup>
-            </Card>
-          </Form>
-        </FormProvider>
+            </Form>
+          </FormProvider>
+        </Card>
       </Container>
       <JsonPreview data={previewJson} onHide={closeModal} />
     </>

--- a/src/components/Wizard/serializers.ts
+++ b/src/components/Wizard/serializers.ts
@@ -219,7 +219,9 @@ function serializeSpotlightButton(data: SpotlightButtonFormData) {
       data.action.navigate ? { navigate: true } : {},
       data.action.dismiss ? { dismiss: true } : {},
       data.action.type ? { type: data.action.type } : {},
-      { data: JSON.parse(data.action.data) as unknown }
+      data.action.type && data.action.data
+        ? { data: JSON.parse(data.action.data) as unknown }
+        : {}
     ),
   };
 }

--- a/src/components/Wizard/wizard.scss
+++ b/src/components/Wizard/wizard.scss
@@ -11,8 +11,9 @@
 
 /* A form grid where each label takes up two columns and each input takes up 10
  * columns.  */
-.form-row,
-.form-col {
+.form-row {
+  --form-row-spacing: 1rem;
+
   & > .form-label {
     @extend .col-form-label;
     @extend .col-2;
@@ -22,6 +23,14 @@
     @extend .col-10;
   }
 
+  & > .row-help-text {
+    @extend .offset-2;
+    @extend .col-10;
+  }
+}
+
+.form-col,
+.form-row {
   & > .form-input-check,
   & > .form-input-range {
     // To match .form-row > .form-label in Bootstrap.
@@ -41,10 +50,6 @@
   .btn:not(:last-child) {
     margin-right: 0.5rem;
   }
-}
-
-.form-row {
-  --form-row-spacing: 1rem;
 }
 
 .form-row + .form-row {

--- a/src/components/Wizard/wizard.scss
+++ b/src/components/Wizard/wizard.scss
@@ -88,9 +88,18 @@
 /* NewEditImportPane specific components */
 
 .edit-form {
+  .form-label {
+    line-height: 2em;
+  }
+
   .edit-entry {
     display: flex;
     font-family: defs.$monospace-font;
+    line-height: 2em;
+
+    .form-check .form-check-input {
+      margin-top: 0.5em;
+    }
   }
 
   .form-check {

--- a/src/components/Wizard/wizard.scss
+++ b/src/components/Wizard/wizard.scss
@@ -7,6 +7,7 @@
 @use "~bootstrap/scss/bootstrap";
 @use "InfoBarWizard/infoBarWizard";
 @use "SpotlightWizard/spotlightWizard";
+@use "../../defs";
 
 /* A form grid where each label takes up two columns and each input takes up 10
  * columns.  */
@@ -88,6 +89,7 @@
 .edit-form {
   .edit-entry {
     display: flex;
+    font-family: defs.$monospace-font;
   }
 
   .form-check {
@@ -127,6 +129,10 @@
     & > .card-header {
       display: flex;
       justify-content: space-between;
+
+      .message-id {
+        font-family: defs.$monospace-font;
+      }
     }
 
     & > .card-body {

--- a/src/components/Wizard/wizard.scss
+++ b/src/components/Wizard/wizard.scss
@@ -92,8 +92,6 @@
 
   .form-check {
     @extend .col-11;
-
-    align-self: center;
   }
 
   .delete-col {

--- a/src/components/Wizard/wizard.scss
+++ b/src/components/Wizard/wizard.scss
@@ -24,7 +24,8 @@
 
   & > .form-input-check,
   & > .form-input-range {
-    padding-top: 0.5rem;
+    // To match .form-row > .form-label in Bootstrap.
+    padding-top: calc(0.375rem + 1px);
   }
 
   & > .row-help-text {

--- a/src/defs.scss
+++ b/src/defs.scss
@@ -1,0 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/* stylelint-disable-next-line value-keyword-case */
+$monospace-font: Menlo, Consolas, "Courier New", monospace;


### PR DESCRIPTION
This series of patches is some semi-related code cleanup:

* The edit form has been fixed so that the input label and checkbox label are aligned correctly with the delete buttons.
* Message IDs are now always monospace.
* Checkboxes and radioboxes are now *actually* aligned with their labels -- they were previously 1px off.
* The `.wizard > .card` styles now actually apply.
* Removed some unused styles.
* Fixed a typo in the `<MessageGroupsInput>` label
* The rich text checkbox in `<LocalizabledTextInput>` is now correctly aligned.
* Transitions are default checked in the `<SpotlightWizard>`.
* Refactor `.form-row` and `.form-col` CSS: `.form-col` now has labels and controls vertically aligned instead of horizontally.
* Minor edit form cleanups.
* Align the rich text checkbox with label in LocalizedTextInput
* Do not require action data for Spotlight buttons