### PR TITLE
Keep track of ref proxies in TabbedInput

### DIFF
--- a/src/components/Wizard/__tests__/TabbedInput.test.tsx
+++ b/src/components/Wizard/__tests__/TabbedInput.test.tsx
@@ -294,5 +294,32 @@ describe("TabbedInput", () => {
         expect(getFocusedElement()).toBe(screen.getAllByLabelText("Text")[0])
       );
     });
+
+    test("LocalizableTextInput toggles correctly inside a TabbedInput", async () => {
+      // Issue 56.
+
+      renderWrapped(<TabbedInput {...defaultProps} />);
+
+      // Add a tab.
+      await userEvent.click(screen.getByTitle(ADD_TAB_TEXT));
+
+      // There should be a text input and not a string ID input.
+      screen.getByLabelText("Text");
+      expect(screen.queryByLabelText("String ID")).toBeNull();
+
+      // Toggle localization checkbox.
+      await userEvent.click(screen.getByLabelText("Localized?"));
+
+      // There should be a string ID input and no text input.
+      screen.getByLabelText("String ID");
+      expect(screen.queryByLabelText("Text")).toBeNull();
+
+      // Toggle localization checkbox.
+      await userEvent.click(screen.getByLabelText("Localized?"));
+
+      // There should be a text input and not a string ID input.
+      screen.getByLabelText("Text");
+      expect(screen.queryByLabelText("String ID")).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
Previously we were re-creating a new `Proxy` on each call to `render()`, resulting in React and react-hook-form thinking that the underlying element had changed. This lead to an accumulation of refs in react-hook-form's internal state for checkbox fields inside `<TabbedInput>`s. This broke `<LocalizableTextInput>` on the `<InfoBarButtonsInput>` and on the `<SpotlightScreensInput>`.

Now we cache our proxies in a `WeakMap` indexed by the DOM element so that we will compare equal between renders as long as the element hasn't changed.

Fixes #56.