### PR TITLE
Mark the order field as deserialized

### DIFF
--- a/src/components/Wizard/deserializers/index.ts
+++ b/src/components/Wizard/deserializers/index.ts
@@ -76,6 +76,7 @@ export default function deserialize(
     "trigger",
     "frequency",
     "priority",
+    "order",
   ]);
 
   return {


### PR DESCRIPTION
We are deserializing the order field but warning that we don't recognize it. This patch removes the warning.